### PR TITLE
feat: raw_request and copy straight into available message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ One of the ways TigerBeetle achieves its performance is through batching. This i
 
 ```js
 const account = {
-    id: 137n, // u64
+    id: 137n, // u128
     user_data: 0n, // u128, opaque third-party identifier to link this account (many-to-one) to an external entity:
     reserved: Buffer.alloc(48, 0), // [48]u8
     unit: 1,   // u16, unit of value
@@ -115,9 +115,9 @@ The `id` of the account is used for lookups. Only matched accounts are returned.
 This creates a journal entry between two accounts.
 ```js
 const transfer = {
-    id: 1n, // u64
-    debit_account_id: 1n,  // u64
-    credit_account_id: 2n, // u64
+    id: 1n, // u128
+    debit_account_id: 1n,  // u128
+    credit_account_id: 2n, // u128
     user_data: 0n, // u128, opaque third-party identifier to link this transfer (many-to-one) to an external entity 
     reserved: Buffer.alloc(32, 0), // two-phase condition can go in here
     timeout: 0n, // u64, in nano-seconds. 
@@ -162,11 +162,11 @@ This is used to commit a two-phase transfer.
 By default (`flags = 0`), it will accept the transfer. TigerBeetle will atomically rollback the changes to `debits_reserved` and `credits_reserved` of the appropriate accounts and apply them to the `debits_accepted` and `credits_accepted` balances. If the `preimage` bit is set then TigerBeetle will look for it in the `reserved` field and validate it against the `condition` from the associated transfer. If this validation fails, or `reject` is set, then the changes to the `reserved` balances are atomically rolled back.
 ```js
 const commit = {
-    id: 1n,   // must correspond to the transfer id
-    reserved: Buffer.alloc(32, 0),
-    code: 1,  // accounting system code to identify type of transfer
-    flags: 0,
-    timestamp: 0n, // Reserved: This will be set by the server.
+    id: 1n,   // u128, must correspond to the transfer id
+    reserved: Buffer.alloc(32, 0), // [32]u8
+    code: 1,  // u32, accounting system code to identify type of transfer
+    flags: 0, // u32
+    timestamp: 0n, // u64, Reserved: This will be set by the server.
 }
 const errors = await client.commitTransfers([commit])
 ```

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -4,20 +4,28 @@ import {
   Account,
   createClient,
   Transfer,
-  TransferFlags
+  TransferFlags,
+  CreateTransfersError,
+  CommitTransfersError,
+  Operation
 } from '.'
 
 const MAX_TRANSFERS = 1000000
 const MAX_REQUEST_BATCH_SIZE = 10000
 const IS_TWO_PHASE_COMMIT = false
-const PREVIOUS_RESULT = IS_TWO_PHASE_COMMIT ? 125000 : 250000
-const RESULT_TOLERANCE = 10 // percent
+const IS_RAW_REQUEST = false
+const PREVIOUS_RAW_REQUEST_RESULT = IS_TWO_PHASE_COMMIT ? 300000 : 620000
+const PREVIOUS_RESULT = IS_TWO_PHASE_COMMIT ? 150000 : 310000
+const PREVIOUS_BENCHMARK = IS_RAW_REQUEST ? PREVIOUS_RAW_REQUEST_RESULT : PREVIOUS_RESULT
+const TOLERANCE = 10 // percent that the benchmark is allowed to deviate from the previous benchmark
 
 const client = createClient({
   cluster_id: 0x0a5ca1ab1ebee11en,
   replica_addresses: ['3001']
 })
 
+const TRANSFER_SIZE = 128
+const COMMIT_SIZE = 64
 const Zeroed48Bytes = Buffer.alloc(48, 0)
 const Zeroed32Bytes = Buffer.alloc(32, 0)
 const accountA: Account = {
@@ -48,55 +56,210 @@ const accountB: Account = {
   timestamp: 0n,
 }
 
-console.log(`pre-allocating ${MAX_TRANSFERS} transfers and commits...`)
-const transfers: Transfer[][] = []
-const commits: Commit[][] = []
+// helper function to promisify the raw_request
+const rawCreateTransfers = async (batch: Buffer): Promise<CreateTransfersError[]> => {
+  return new Promise((resolve, reject) => {
+      const callback = (error: undefined | Error, results: CreateTransfersError[]) => {
+        if (error) {
+          reject(error)
+        }
+        resolve(results)
+      }
 
-let count = 0
-while (count < MAX_TRANSFERS) {
-  const transferBatch: Transfer[] = []
-  const commitBatch: Commit[] = []
-  for (let i = 0; i < MAX_REQUEST_BATCH_SIZE; i++) {
-    if (count === MAX_TRANSFERS) break
-
-    count += 1
-    transferBatch.push({
-      id: BigInt(count),
-      debit_account_id: accountA.id,
-      credit_account_id: accountB.id,
-      code: 0,
-      reserved: Zeroed32Bytes,
-      user_data: 0n,
-      flags: IS_TWO_PHASE_COMMIT ? TransferFlags.two_phase_commit : 0,
-      amount: 1n,
-      timeout: IS_TWO_PHASE_COMMIT ? BigInt(2e9) : 0n,
-      timestamp: 0n,
+      try {
+        client.rawRequest(Operation.CREATE_TRANSFER, batch, callback)
+      } catch (error) {
+        reject(error)
+      }
     })
-  
+}
+
+// helper function to promisify the raw_request
+const rawCommitTransfers = async (batch: Buffer): Promise<CommitTransfersError[]> => {
+  return new Promise((resolve, reject) => {
+      const callback = (error: undefined | Error, results: CommitTransfersError[]) => {
+        if (error) {
+          reject(error)
+        }
+        resolve(results)
+      }
+
+      try {
+        client.rawRequest(Operation.COMMIT_TRANSFER, batch, callback)
+      } catch (error) {
+        reject(error)
+      }
+    })
+}
+
+/**
+ * This encoding function is only for this benchmark script.
+ * 
+ * ID_OFFSET = 0
+ * DEBIT_ACCOUNT_ID_OFFSET = 0 + 16 = 16
+ * CREDIT_ACCOUNT_ID_OFFSET = 16 + 16 = 32
+ * USER_DATA_OFFSET = 32 + 16 = 48
+ * RESERVED_OFFSET = 48 + 16 = 64
+ * TIMEOUT_OFFSET = 64 + 32 = 96
+ * CODE_OFFSET = 96 + 8 = 104
+ * FLAGS_OFFSET = 104 + 4 = 108
+ * AMOUNT_OFFSET = 108 + 4 = 112
+ * TIMESTAMP_OFFSET = 112 + 8 = 120
+ */ 
+const encodeTransfer = (transfer: Transfer, offset: number, output: Buffer): void => {
+  assert(offset + TRANSFER_SIZE <= output.length)
+
+   output.writeBigUInt64LE(transfer.id, offset)
+   output.writeBigUInt64LE(transfer.debit_account_id, offset + 16)
+   output.writeBigUInt64LE(transfer.credit_account_id, offset + 32)
+   output.writeBigUInt64LE(transfer.timeout, offset + 96)
+   output.writeUInt32LE(transfer.code, offset + 104)
+   output.writeUInt32LE(transfer.flags, offset + 108)
+   output.writeBigUInt64LE(transfer.amount, offset + 112)
+   output.writeBigUInt64LE(transfer.timestamp, offset + 120)
+}
+
+// This encoding function is only for this benchmark script.
+const encodeCommit = (commit: Commit, offset: number, output: Buffer): void => {
+  assert(offset + COMMIT_SIZE <= output.length)
+
+  output.writeBigUInt64LE(commit.id, offset)
+}
+
+const runBenchmarkRawReqeust = async () => {
+  assert(
+    MAX_TRANSFERS % MAX_REQUEST_BATCH_SIZE === 0,
+    "The raw request benchmark requires MAX_TRANSFERS to be a multiple of MAX_REQUEST_BATCH_SIZE"
+  )
+  console.log(`pre-allocating ${MAX_TRANSFERS} transfers and commits...`)
+  const transfers: Buffer[] = []
+  const commits: Buffer[] = []
+
+  let count = 0
+  while (count < MAX_TRANSFERS) {
+    const transferBatch = Buffer.alloc(MAX_REQUEST_BATCH_SIZE * TRANSFER_SIZE, 0)
+    const commitBatch = Buffer.alloc(MAX_REQUEST_BATCH_SIZE * COMMIT_SIZE, 0)
+    for (let i = 0; i < MAX_REQUEST_BATCH_SIZE; i++) {
+      if (count === MAX_TRANSFERS) break
+
+      count += 1
+      encodeTransfer(
+        {
+          id: BigInt(count),
+          debit_account_id: accountA.id,
+          credit_account_id: accountB.id,
+          code: 0,
+          reserved: Zeroed32Bytes,
+          user_data: 0n,
+          flags: IS_TWO_PHASE_COMMIT ? TransferFlags.two_phase_commit : 0,
+          amount: 1n,
+          timeout: IS_TWO_PHASE_COMMIT ? BigInt(2e9) : 0n,
+          timestamp: 0n,
+        },
+        i * TRANSFER_SIZE,
+        transferBatch
+      )
+    
+      if (IS_TWO_PHASE_COMMIT) {
+        encodeCommit(
+          {
+            id: BigInt(count),
+            reserved: Buffer.alloc(32, 0),
+            code: 0,
+            flags: 0,
+            timestamp: 0n,
+          },
+          i * COMMIT_SIZE,
+          commitBatch 
+        )
+      }
+    }
+
+    transfers.push(transferBatch)
+    if (IS_TWO_PHASE_COMMIT) commits.push(commitBatch)
+  }
+  assert(count === MAX_TRANSFERS)
+
+  console.log(`starting benchmark. MAX_TRANSFERS=${MAX_TRANSFERS} REQUEST_BATCH_SIZE=${MAX_REQUEST_BATCH_SIZE} NUMBER_OF_BATCHES=${transfers.length}`)
+  let maxCreateTransfersLatency = 0
+  let maxCommitTransfersLatency = 0
+  const start = Date.now()
+
+  for(let i = 0; i < transfers.length; i++) {
+    const ms1 = Date.now()
+
+    const transferResults = await rawCreateTransfers(transfers[i])
+    assert(transferResults.length === 0)
+
+    const ms2 = Date.now()
+    const createTransferLatency = ms2 - ms1
+    if (createTransferLatency > maxCreateTransfersLatency) {
+      maxCreateTransfersLatency = createTransferLatency
+    }
+
     if (IS_TWO_PHASE_COMMIT) {
-      commitBatch.push({
-        id: BigInt(count),
-        reserved: Buffer.alloc(32, 0),
-        code: 0,
-        flags: 0,
-        timestamp: 0n,
-      })
+      const commitResults = await rawCommitTransfers(commits[i])
+      assert(commitResults.length === 0)
+
+      const ms3 = Date.now()
+      const commitTransferLatency = ms3 - ms2
+      if (commitTransferLatency > maxCommitTransfersLatency) {
+        maxCommitTransfersLatency = commitTransferLatency
+      }
     }
   }
 
-  transfers.push(transferBatch)
-  if (IS_TWO_PHASE_COMMIT) commits.push(commitBatch)
-}
-assert(count === MAX_TRANSFERS)
+  const ms = Date.now() - start
 
-const main = async () => {
-  console.log("creating the accounts...")
-  await client.createAccounts([accountA, accountB])
-  const accountResults = await client.lookupAccounts([accountA.id, accountB.id])
-  assert(accountResults.length === 2)
-  assert(accountResults[0].debits_accepted === 0n)
-  assert(accountResults[1].debits_accepted === 0n)
-  
+  return {
+    ms,
+    maxCommitTransfersLatency,
+    maxCreateTransfersLatency
+  }
+}
+
+const runBenchmark = async () => {
+  console.log(`pre-allocating ${MAX_TRANSFERS} transfers and commits...`)
+  const transfers: Transfer[][] = []
+  const commits: Commit[][] = []
+
+  let count = 0
+  while (count < MAX_TRANSFERS) {
+    const transferBatch: Transfer[] = []
+    const commitBatch: Commit[] = []
+    for (let i = 0; i < MAX_REQUEST_BATCH_SIZE; i++) {
+      if (count === MAX_TRANSFERS) break
+
+      count += 1
+      transferBatch.push({
+        id: BigInt(count),
+        debit_account_id: accountA.id,
+        credit_account_id: accountB.id,
+        code: 0,
+        reserved: Zeroed32Bytes,
+        user_data: 0n,
+        flags: IS_TWO_PHASE_COMMIT ? TransferFlags.two_phase_commit : 0,
+        amount: 1n,
+        timeout: IS_TWO_PHASE_COMMIT ? BigInt(2e9) : 0n,
+        timestamp: 0n,
+      })
+    
+      if (IS_TWO_PHASE_COMMIT) {
+        commitBatch.push({
+          id: BigInt(count),
+          reserved: Buffer.alloc(32, 0),
+          code: 0,
+          flags: 0,
+          timestamp: 0n,
+        })
+      }
+    }
+
+    transfers.push(transferBatch)
+    if (IS_TWO_PHASE_COMMIT) commits.push(commitBatch)
+  }
+  assert(count === MAX_TRANSFERS)
+
   console.log(`starting benchmark. MAX_TRANSFERS=${MAX_TRANSFERS} REQUEST_BATCH_SIZE=${MAX_REQUEST_BATCH_SIZE} NUMBER_OF_BATCHES=${transfers.length}`)
   let maxCreateTransfersLatency = 0
   let maxCommitTransfersLatency = 0
@@ -127,18 +290,36 @@ const main = async () => {
   }
 
   const ms = Date.now() - start
+
+  return {
+    ms,
+    maxCommitTransfersLatency,
+    maxCreateTransfersLatency
+  }
+}
+
+const main = async () => {  
+  console.log("creating the accounts...")
+  await client.createAccounts([accountA, accountB])
+  const accountResults = await client.lookupAccounts([accountA.id, accountB.id])
+  assert(accountResults.length === 2)
+  assert(accountResults[0].debits_accepted === 0n)
+  assert(accountResults[1].debits_accepted === 0n)
+
+  const benchmark = IS_RAW_REQUEST ? await runBenchmarkRawReqeust() : await runBenchmark() 
+  
   const accounts = await client.lookupAccounts([accountA.id, accountB.id])
-  const result = Math.floor((1000 * MAX_TRANSFERS)/ms)
+  const result = Math.floor((1000 * MAX_TRANSFERS)/benchmark.ms)
   console.log("=============================")
   console.log(`${IS_TWO_PHASE_COMMIT ? 'two-phase ' : ''}transfers per second: ${result}`)
-  console.log(`create transfers max p100 latency per 10 000 transfers = ${maxCreateTransfersLatency}ms`)
-  console.log(`commit transfers max p100 latency per 10 000 transfers = ${maxCommitTransfersLatency}ms`)
+  console.log(`create transfers max p100 latency per 10 000 transfers = ${benchmark.maxCreateTransfersLatency}ms`)
+  console.log(`commit transfers max p100 latency per 10 000 transfers = ${benchmark.maxCommitTransfersLatency}ms`)
   assert(accounts.length === 2)
   assert(accounts[0].debits_accepted === BigInt(MAX_TRANSFERS))
   assert(accounts[1].credits_accepted === BigInt(MAX_TRANSFERS))
 
-  if (result < PREVIOUS_RESULT * (100 - RESULT_TOLERANCE)/100) {
-    console.warn(`There has been a performance regression. Previous benchmark=${PREVIOUS_RESULT}`)
+  if (result < PREVIOUS_BENCHMARK * (100 - TOLERANCE)/100) {
+    console.warn(`There has been a performance regression. Previous benchmark=${PREVIOUS_BENCHMARK}`)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ const binding: Binding = require('./client.node')
 interface Binding {
   init: (args: BindingInitArgs) => Context
   request: (context: Context, operation: Operation, batch: Event[], result: ResultCallback) => void
+  raw_request: (context: Context, operation: Operation, raw_batch: Buffer, result: ResultCallback) => void
   tick: (context: Context) => void,
   deinit: (context: Context) => void
 }
@@ -167,6 +168,7 @@ export interface Client {
   commitTransfers: (batch: Commit[]) => Promise<CommitTransfersError[]>
   lookupAccounts: (batch: AccountID[]) => Promise<Account[]>
   request: (operation: Operation, batch: Event[], callback: ResultCallback) => void
+  rawRequest: (operation: Operation, rawBatch: Buffer, callback: ResultCallback) => void
   destroy: () => void
 }
 
@@ -214,6 +216,10 @@ export function createClient (args: InitArgs): Client {
 
   const request = (operation: Operation, batch: Event[], callback: ResultCallback) => {
     binding.request(context, operation, batch, callback)
+  }
+
+  const rawRequest = (operation: Operation, rawBatch: Buffer, callback: ResultCallback) => {
+    binding.raw_request(context, operation, rawBatch, callback)
   }
 
   const createAccounts = async (batch: Account[]): Promise<CreateAccountsError[]> => {
@@ -325,6 +331,7 @@ export function createClient (args: InitArgs): Client {
     commitTransfers,
     lookupAccounts,
     request,
+    rawRequest,
     destroy
   }
 


### PR DESCRIPTION
`request`has been refactored to retrieve an available message from the
message bus and translate the incoming batch directly into it.

`raw_request` allows the user to handle the encoding themselves and give
the client a slice of bytes to send. This greatly improves performance
as only one copy into the available message is performed.

The README has also been updated with the correct data types.

Upstream has been updated.

Benchmark scripts updated to run `raw_request` as well.