### PR TITLE
Issue #52 - Remove `already_auto_committed`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,6 @@ export enum CommitTransferError {
   transfer_not_found,
   transfer_not_two_phase_commit,
   transfer_expired,
-  already_auto_committed,
   already_committed,
   already_committed_but_accepted,
   already_committed_but_rejected,


### PR DESCRIPTION
Remove `already_auto_committed` enum

Please see; 
https://github.com/coilhq/tigerbeetle/issues/52
https://github.com/coilhq/tigerbeetle/pull/55

